### PR TITLE
chore: disable repository auto updates

### DIFF
--- a/.mobsuccess.yml
+++ b/.mobsuccess.yml
@@ -1,0 +1,2 @@
+policy:
+  ignoreUpdateRepo: true


### PR DESCRIPTION
This pull request includes a small change to the `.mobsuccess.yml` file. The change adds a policy to ignore repository updates.

* [`.mobsuccess.yml`](diffhunk://#diff-cc8f4bbcfdd8bb94237b941e25222597112f9bf097ff7635bc0cdb9345e29558R1-R2): Added `ignoreUpdateRepo` policy to the configuration.